### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,9 @@ h2
     text-align: center;
 }
 </style>
-##Release Notes##
+## Release Notes ##
 
-###Version 0.3.2.5
+### Version 0.3.2.5
 
 * Bug fixed: if a decrypted passphrase-only EPD file contained less than 4 characters, the content was ignored and EncryptPad produced an empty file. It happened because EncryptPad expected to find IWAD marker, which was 4 character long. Such files will now open correctly.
 * Bug fixed: when opening a plain-text file and saving it as encrypted, the encryption parameters did not reset to the default values but used the parameters of the last encrypted file.
@@ -26,7 +26,7 @@ h2
 * stlplus was updated from upstream. It is now 3.13.
 
 
-###Version 0.3.2.3
+### Version 0.3.2.3
 
 * Configurable s2k iteration count. It can be set per file and the default value for new files. That value is also used for protecting file keys.
 * Support for the timestamp bytes in GPG files.
@@ -39,7 +39,7 @@ h2
 * Bug fixed: In the file encryption dialogue, when clearing the passphrase and setting it again, the passphrase was ignored and the file was saved as "key only".
 * Bug fixed: In the file encryption, gpg files were encrypted with 't' flag. It lead to removal of 0x0D bytes when GPG decrypted the files because it thought that the files were textual. The problem did not manifest on Windows and when EncryptPad was used for decryption. It was only in the direction from EncryptPad to Linux/Unix GPG.
 
-###Version 0.3.2.2
+### Version 0.3.2.2
 
 * Bug fixed: In file encryption dialogue, when the key file passphrase was wrong, a message box did not inform the user.
 * BAK files support. When editing, a bak file is only created when saving for the first time.
@@ -55,7 +55,7 @@ h2
 * Fixed build on Fedora 23
 * Fixed warnings
 
-###Version 0.3.2.1
+### Version 0.3.2.1
 
 * Initial open source release
 

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,11 +1,11 @@
-#Contributions
+# Contributions
 
-##Overview
+## Overview
 
 This directory is for utilities, scripts, documents and examples related to EncryptPad. You will
 find descriptions and feedback contacts in the list below and source files in each subdirectory.
 
-##List
+## List
 
 ## `gpgvim`
 

--- a/docs/en/changes.md
+++ b/docs/en/changes.md
@@ -4,9 +4,9 @@ h2
     text-align: center;
 }
 </style>
-##Release Notes##
+## Release Notes ##
 
-###Version 0.3.2.5
+### Version 0.3.2.5
 
 * Bug fixed: if a decrypted passphrase-only EPD file contained less than 4 characters, the content was ignored and EncryptPad produced an empty file. It happened because EncryptPad expected to find IWAD marker, which was 4 character long. Such files will now open correctly.
 * Bug fixed: when opening a plain-text file and saving it as encrypted, the encryption parameters did not reset to the default values but used the parameters of the last encrypted file.
@@ -26,7 +26,7 @@ h2
 * stlplus was updated from upstream. It is now 3.13.
 
 
-###Version 0.3.2.3
+### Version 0.3.2.3
 
 * Configurable s2k iteration count. It can be set per file and the default value for new files. That value is also used for protecting file keys.
 * Support for the timestamp bytes in GPG files.
@@ -39,7 +39,7 @@ h2
 * Bug fixed: In the file encryption dialogue, when clearing the passphrase and setting it again, the passphrase was ignored and the file was saved as "key only".
 * Bug fixed: In the file encryption, gpg files were encrypted with 't' flag. It lead to removal of 0x0D bytes when GPG decrypted the files because it thought that the files were textual. The problem did not manifest on Windows and when EncryptPad was used for decryption. It was only in the direction from EncryptPad to Linux/Unix GPG.
 
-###Version 0.3.2.2
+### Version 0.3.2.2
 
 * Bug fixed: In file encryption dialogue, when the key file passphrase was wrong, a message box did not inform the user.
 * BAK files support. When editing, a bak file is only created when saving for the first time.
@@ -55,7 +55,7 @@ h2
 * Fixed build on Fedora 23
 * Fixed warnings
 
-###Version 0.3.2.1
+### Version 0.3.2.1
 
 * Initial open source release
 

--- a/docs/en/readme.md
+++ b/docs/en/readme.md
@@ -1,6 +1,6 @@
 EncryptPad is an application for viewing and editing symmetrically encrypted text. Using a simple and convenient graphical and command line interface, EncryptPad provides a tool for encrypting and decrypting binary files on disk while offering effective measures for protecting information, and it uses the most widely chosen quality file format **OpenPGP** [RFC 4880](https://tools.ietf.org/html/rfc4880). Unlike other OpenPGP software which main purpose is asymmetric encryption, the primary focus of EncryptPad is symmetric encryption.
 
-##Table of Contents
+## Table of Contents
 * [Features](#features)
 * [Supported platforms](#supported-platforms)
 * [Why use EncryptPad?](#why-use-encryptpad)
@@ -34,7 +34,7 @@ EncryptPad is an application for viewing and editing symmetrically encrypted tex
 * [Contact and feedback](#contact)
 
 <div id="features"></div>
-##Features
+## Features
 
 * **Symmetric** encryption
 * **Passphrase** protection
@@ -57,7 +57,7 @@ EncryptPad is an application for viewing and editing symmetrically encrypted tex
 * Compression: **ZLIB, ZIP**
 
 <div id="supported-platforms"></div>
-##Supported platforms
+## Supported platforms
 
 * Windows
 
@@ -66,7 +66,7 @@ EncryptPad is an application for viewing and editing symmetrically encrypted tex
 * Mac OS
 
 <div id="why-use-encryptpad"></div>
-##Why use EncryptPad?
+## Why use EncryptPad?
 
 * **Multi-platform** codebase: it has been compiled on three popular operating systems and can be adapted to more.
 
@@ -81,7 +81,7 @@ EncryptPad is an application for viewing and editing symmetrically encrypted tex
 * **Double protection**: randomly generated key files in addition to passphrases.
 
 <div id="when-encryptpad"></div>
-##When do I need EncryptPad?
+## When do I need EncryptPad?
 
 * You have a file containing sensitive information such as account names, passphrases or IDs. It is stored on an unprotected media or you can't control who accesses the file, whether it is located on a computer at work, a laptop while on the move, a memory stick or a cloud drive.
 
@@ -92,7 +92,7 @@ EncryptPad is an application for viewing and editing symmetrically encrypted tex
 * You need protection against a brute force attack in case your storage gets in somebody's hands. EncryptPad allows to generate a key and store it separately from encrypted information. The unwanted person would need two secrets to open an encrypted file: the passphrase and the key. Consider this example: you store your encrypted file on a memory stick, and protect it with a passphrase. In addition to that, you protect the file with a file key and store the key on computers where you open the file. If the memory stick is lost, the passphrase is not enough to decrypt your information. The key file is also needed and it is not on the memory stick.
 
 <div id="when-can-i-not"></div>
-##When can I not use EncryptPad?
+## When can I not use EncryptPad?
 
 * You need to send a file to somebody with whom you have **not prearranged a shared secret** (a passphrase or a key file). In this case, you need asymmetric encryption with public and private keys. Fortunately, there are many convenient tools suitable for the task. 
 
@@ -105,7 +105,7 @@ EncryptPad is an application for viewing and editing symmetrically encrypted tex
 * **IMPORTANT**: If you forgot your passphrase or lost a key file, there is nothing that can be done to open your encrypted information. There are no backdoors in the formats that EncryptPad supports. EncryptPad developers take no responsibility for corrupted or invalid files in accordance with the license.
 
 <div id="file-types"></div>
-##File types
+## File types
 
 The format is determined by an extension of a file. Main extensions of encrypted files are GPG and EPD.
 
@@ -137,7 +137,7 @@ EncryptPad specific format. Other OpenPGP software will not be able to open it u
 \* Key file location is persisted in the header of an encrypted file so the user does not need to specify it when decrypting.
 
 <div id="key-file"></div>
-##What is an EncryptPad key file?
+## What is an EncryptPad key file?
 In symmetric encryption the same sequence is used to encrypt and decrypt data. The user or another
 application usually provides this sequence in the form of an entered passphrase or a file. In addition to
 entered passphrases, EncryptPad generates files with random sequences called "key files".
@@ -173,7 +173,7 @@ When EncryptPad opens the encrypted file protected with `foo.key`, the equivalen
 As you see, other OpenPGP implementations can also use EncryptPad keys.
 
 <div id="epd-file-format"></div>
-##EPD file format when encrypting with a key
+## EPD file format when encrypting with a key
 
 There are three different structures a saved file can have depending on protection mode:
 
@@ -186,7 +186,7 @@ There are three different structures a saved file can have depending on protecti
 3. **Protected with passphrase and key**. The resulting file is an OpenPGP file containing a WAD file as explained in 2.
 
 <div id="use-curl"></div>
-##Use CURL to automatically download keys from a remote storage
+## Use CURL to automatically download keys from a remote storage
 
 If **[CURL](http://curl.haxx.se/)** URL is specified in **Key File Path** field in the **Set Encryption Key** dialogue, EncryptPad will attempt to start a curl process to download the key from a remote host. If you want to use this feature, you need to set the path to the CURL executable in the EncryptPad settings. 
 
@@ -199,12 +199,12 @@ Consider this use case scenario: you travel with your laptop and open an encrypt
 If this file gets into the hands of a wrongdoer, he or she will need to brute force the passphrase first to be able to obtain the key URL and the authentication parameters. Since a brute force attack takes a lot of time, the user will be able to remove the key or change the authentication so the previous parameters become obsolete.
 
 <div id="known-weaknesses"></div>
-##Known weaknesses
+## Known weaknesses
 
 * EncryptPad stores unencrypted text in memory. If a memory dump is automatically taken after a system or application crash or some of the memory is saved to a swap file, the sensitive information will be present on the disk. Sometimes it is possible to configure an operating system not to use a dump and swap files. It is a good practice to close EncryptPad when not in use.
 
 <div id="command-line-interface"></div>
-##Command line interface
+## Command line interface
 
 **encryptcli** is the executable to encrypt / decrypt files in command line. Run it without
 arguments to see available parameters. Below is an example of encrypting a file with a key:
@@ -219,16 +219,16 @@ arguments to see available parameters. Below is an example of encrypting a file 
     --key-only --key-pwd-fd 3 -o plain_text.txt.gpg 3< <(echo -n "key")
 
 <div id="installing"></div>
-##Installing EncryptPad
+## Installing EncryptPad
 
 <div id="portable-exe"></div>
-###Portable executable
+### Portable executable
 
 Portable binaries are available for Windows and macOS. They can be copied on a memory stick or
 placed on a network share.
 
 <div id="install-on-arch"></div>
-###Arch Linux
+### Arch Linux
 
 Use fingerprints to receive gpg keys for EncryptPad and Botan.
 
@@ -243,7 +243,7 @@ Install the AUR packages below:
 `pacaur` installs `botan-stable` automatically as `encryptpad` dependency.
 
 <div id="install-on-ubuntu"></div>
-###Ubuntu or Linux Mint via PPA
+### Ubuntu or Linux Mint via PPA
 
 Alin Andrei from [**webupd8.org**](http://webupd8.org) kindly created EncryptPad packages for
 several distributions. See instructions below on how to install them.
@@ -304,17 +304,17 @@ Below are steps to verify the SHA-1 hashes of the source files in [Launchpad web
     encryptpad0_3_2_5_webupd8_ppa_changes/encryptpad_0.3.2.5-1~webupd8~yakkety1_source.changes
 
 <div id="compile-on-windows"></div>
-##Compile EncryptPad on Windows
+## Compile EncryptPad on Windows
 
 <div id="prerequisites"></div>
-###Prerequisites
+### Prerequisites
 
 1. [**Qt framework**](http://www.qt.io/download-open-source/) based on MingW 32 bit (the latest build has been tested with Qt 5.3.2).
 2. MSYS: you can use one bundled with [**Git For Windows**](http://git-scm.com/download/win). You probably use Git anyway.
 3. Python: any recent version will work.
 
 <div id="steps"></div>
-###Steps
+### Steps
 
 1. Modify the session **PATH** environment variable to include the Qt build toolset and Python. **mingw32-make**, **g++**, **qmake**, **python.exe** should be in the global search path in your Git Bash session. I personally modify bash.bashrc and add a line like `PATH=$PATH:/c/Python35-32:...` not to pollute the system wide PATH variable.
 
@@ -335,14 +335,14 @@ If the build is successful, you should see the executable **./bin/release/Encryp
 Note that if you want EncryptPad to work as a single executable without dlls, you need to build Qt framework yourself statically. It takes a few hours. There are plenty of instructions on how to do this in the Internet. The most popular article recommends using a PowerShell script. While it is convenient and I did it once, sometimes you don't want to upgrade your PowerShell and install heavy dependencies coming with it. So the next time I had to do that, I read the script and did everything manually. Luckily there are not too many steps in it.
 
 <div id="compile-on-mac-linux"></div>
-##Compile EncryptPad on Mac/Linux
+## Compile EncryptPad on Mac/Linux
 
 It is easier than building on Windows. All you need is to install Qt, Python and run:
 
     ./configure.sh --all
 
 <div id="dynamic-build"></div>
-###Dynamic build
+### Dynamic build
 
     ./configure.sh --all --use-system-libs
 
@@ -351,7 +351,7 @@ of compiling their source code under `deps`. On Ubuntu, install `libbotan1.10-de
 packages before building.
 
 <div id="build-on-fedora"></div>
-###Fedora###
+### Fedora ###
 
 Install dependencies and tools:
 
@@ -369,11 +369,11 @@ For a dynamic build with using the system libraries:
     ./configure.sh --all --use-system-libs
 
 <div id="passphrases-in-memory"></div>
-##Does EncryptPad store passphrases in the memory to reopen files?
+## Does EncryptPad store passphrases in the memory to reopen files?
 No, it does not. After being entered, a passphrase and random salt are hashed with an S2K algorithm. The result is used as the encryption key to encrypt or decrypt the file. A pool of these S2K results is generated every time the user enters a new passphrase. It allows to save and load files protected with this passphrase multiple times without having the passphrase. The size of the pool can be changed in the Preferences dialogue. The latest version at the moment of writing has this number set to 8 by default. It means that you can save a file 8 times before EncryptPad will ask you to enter the passphrase again. You can increase this number but it will have an impact on the performance because S2K algorithms with many iterations are slow by design.
 
 <div id="acknowledgements"></div>
-##Acknowledgements
+## Acknowledgements
 
 EncryptPad uses the following frameworks and libraries:
 
@@ -386,10 +386,10 @@ EncryptPad uses the following frameworks and libraries:
 7. [**famfamfam Silk iconset 1.3**](http://www.famfamfam.com/lab/icons/silk/)
 
 <div id="integrity-verification"></div>
-##EncryptPad integrity verification
+## EncryptPad integrity verification
 
 <div id="openpgp-signing"></div>
-###OpenPGP signing and certification authority
+### OpenPGP signing and certification authority
 
 All EncryptPad related downloads are signed with the following OpenPGP key.
 
@@ -416,7 +416,7 @@ There is a few reasons why I did not simply use the CA certificate:
 4. Verify signatures on the downloaded files with GPG.
 
 <div id="license"></div>
-##License
+## License
 
 EncryptPad is free software: you can redistribute it and/or modify
 it under the terms of the [GNU General Public License](http://www.gnu.org/licenses/) as published by
@@ -429,7 +429,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 <div id="contact"></div>
-##Contact and feedback
+## Contact and feedback
 
 If your question is related to EncryptPad, send it to the mailing list: **encryptpad@googlegroups.com** linked to [the public discussion group](https://groups.google.com/d/forum/encryptpad).
 

--- a/docs/en/tutorials/encrypt_binary_file/binary_file.md
+++ b/docs/en/tutorials/encrypt_binary_file/binary_file.md
@@ -1,4 +1,4 @@
-#Encrypt a binary file such as a picture or an archive
+# Encrypt a binary file such as a picture or an archive
 
 ## Generate a new key file if you want to use a key file for encryption.
 

--- a/docs/en/tutorials/index.md
+++ b/docs/en/tutorials/index.md
@@ -4,12 +4,12 @@ h2
     text-align: center;
 }
 </style>
-##Tutorials
+## Tutorials
 
-###[1. Open a plain text file, protect it with *a passphrase* and save as a GPG file](open_plain_text_protect_with_passphrase/passphrase_protection.htm)
+### [1. Open a plain text file, protect it with *a passphrase* and save as a GPG file](open_plain_text_protect_with_passphrase/passphrase_protection.htm)
 
-###[2. Open a plain text file, protect it with *a key file* and save as a GPG file](open_plain_text_protect_with_key_file/key_file_protection.htm)
+### [2. Open a plain text file, protect it with *a key file* and save as a GPG file](open_plain_text_protect_with_key_file/key_file_protection.htm)
 
-###[3. Open a plain text file, protect it with both *a passphrase and key file* then save it as an EPD file](open_plain_text_protect_with_key_and_passphrase/double_protection.htm)
+### [3. Open a plain text file, protect it with both *a passphrase and key file* then save it as an EPD file](open_plain_text_protect_with_key_and_passphrase/double_protection.htm)
 
-###[4. Encrypt a binary file such as a picture or an archive](encrypt_binary_file/binary_file.htm)
+### [4. Encrypt a binary file such as a picture or an archive](encrypt_binary_file/binary_file.htm)

--- a/docs/fr/changes.md
+++ b/docs/fr/changes.md
@@ -4,9 +4,9 @@ h2
     text-align: center;
 }
 </style>
-##Notes de version##
+## Notes de version ##
 
-###Version 0.3.2.5
+### Version 0.3.2.5
 
 * Correctif de bogue : si un fichier EPD «&nbsp;phrase de passe seulement&nbsp&nbsp;» déchiffré comprenait moins de 4 caractères, le contenu était ignoré et EncryptPad produisait un fichier vide. Cela se produisait, car EncryptPad  s'attendait à trouver un marqueur IWAD de 4 caractères. Ces fichiers seront maintenant ouverts correctement.
 * Correctif de bogue : si un fichier texte en clair était ouvert puis enregistré chiffré, les paramètres de chiffrement n'étaient pas réinitialisés aux valeurs par défaut, mais utilisaient les paramètres du dernier fichier chiffré.
@@ -26,7 +26,7 @@ h2
 * stlplus a été mise à jour vers 3.13.
 
 
-###Version 0.3.2.3
+### Version 0.3.2.3
 
 * Nombre configurable d'itérations S2K. Il peut être été fini par fichier, et comme valeur par défaut pour les nouveaux fichiers. Cette valeur est aussi utilisée pour la protection des fichiers.
 * Prise en charge des octets d'estampille temporelle dans les fichiers GPG.
@@ -39,7 +39,7 @@ h2
 * Correctif de bogue : dans la boîte de dialogue «&nbsp;Chiffrement du fichier&nbsp;», quand la phrase de passe était effacée puis redéfinie, la phrase de passe était ignorée et le fichier était enregistré comme «&nbsp;clé seulement&nbsp;».
 * Correctif de bogue : dans le chiffrement des fichiers, les fichiers gpg étaient chiffrés avec le drapeau «&nbsp;t&nbsp;», ce qui entraînait la suppression de 0x0D octets quand GPG déchiffrait les fichiers, car il croyait que les fichiers étaient textuels. Le problème ne se produisait pas sous Windows ni quand EncryptPad était utilisé pour le déchiffrement. Cela ne se produisait que dans la direction EncryptPad vers GPG pour Linux/Unix.
 
-###Version 0.3.2.2
+### Version 0.3.2.2
 
 * Correctif de bogue : dans la boîte de dialogue «&nbsp;Chiffrement du fichier&nbsp;», lorsque la phrase de passe du fichier clé était erronée, un message n'en informait pas l'utilisateur.
 * Prise en charge des fichiers BAK. Lors d'une modification, un fichier bak n'est crée que lors du premier enregistrement.
@@ -55,6 +55,6 @@ h2
 * Correctif de la compilation sous Fedora 23
 * Correctif des avertissements
 
-###Version 0.3.2.1
+### Version 0.3.2.1
 
 * Première version à code source ouvert

--- a/docs/fr/readme.md
+++ b/docs/fr/readme.md
@@ -1,6 +1,6 @@
 EncryptPad est une application de visualisation et d'édition de texte chiffré symétriquement. Grâce à son interface graphique et en ligne de commande simple, EncryptPad propose un outil pour chiffrer et déchiffrer des fichiers binaires sur le disque, tout en offrant des mesures efficaces pour protéger les informations. De plus, EncryptPad utilise le format de fichier **OpenPGP** [RFC 4880](https://tools.ietf.org/html/rfc4880) qui est largement adopté pour sa qualité. Contrairement à d'autres logiciels OpenPGP dont le but principal est le chiffrement asymétrique, l'objectif premier d'EncryptPad est le chiffrement symétrique.
 
-##Table des matières
+## Table des matières
 * [Caractéristiques](#features)
 * [Plateformes prises en charge](#supported-platforms)
 * [Pourquoi utiliser EncryptPad ?](#why-use-encryptpad)
@@ -34,7 +34,7 @@ EncryptPad est une application de visualisation et d'édition de texte chiffré 
 * [Contact et rétroaction](#contacts)
 
 <div id="features"></div>
-##Caractéristiques
+## Caractéristiques
 
 * Chiffrement **symétrique**
 * Protection par **phrase de passe**
@@ -57,7 +57,7 @@ EncryptPad est une application de visualisation et d'édition de texte chiffré 
 * Compression : **ZLIB, ZIP**
 
 <div id="supported-platforms"></div>
-##Plateformes prises en charge
+## Plateformes prises en charge
 
 * Windows
 
@@ -66,7 +66,7 @@ EncryptPad est une application de visualisation et d'édition de texte chiffré 
 * Mac OS
 
 <div id="why-use-encryptpad"></div>
-##Pourquoi utiliser EncryptPad ?
+## Pourquoi utiliser EncryptPad ?
 
 * Code base **multiplateforme : EncryptPad a été compilé sur trois systèmes d'exploitation populaires et peut être adapté à d'autres.
 
@@ -81,7 +81,7 @@ EncryptPad est une application de visualisation et d'édition de texte chiffré 
 * **Protection double** : des fichiers clés générés aléatoirement en plus de phrases de passe.
 
 <div id="when-encryptpad"></div>
-##Quand ai-je besoin d'EncryptPad ?
+## Quand ai-je besoin d'EncryptPad ?
 
 * Vous avez un fichier contenant des informations délicates telles que des noms de compte, des phrases de passe ou des numéros d'identification. Ce fichier est stocké sur un support sans protection, ou vous ne pouvez pas contrôler qui y accède, que ce soit au travail, sur un ordinateur portable lors de déplacements, une clé USB ou un disque nuagique.
 
@@ -92,7 +92,7 @@ EncryptPad est une application de visualisation et d'édition de texte chiffré 
 * Vous devez être protégé contre une attaque par force brute au cas où votre moyen de stockage tomberait dans les mains de quelqu'un. EncryptPad permet de générer une clé et de la stocker séparément des informations chiffrées. Une personne non autorisée aurait besoin de deux secrets pour ouvrir un fichier : la phrase de passe et la clé. Examinons cet exemple : vous stockez votre fichier chiffré sur une carte mémoire flash et vous le protégez par phrase de passe. De plus, vous protégez le fichier avec un fichier clé et stockez la clé sur les ordinateurs utilisés pour ouvrir le fichier. Si la carte mémoire flash est perdue, la phrase de passe ne suffira pas pour déchiffrer vos informations. Le fichier clé est aussi exigé, et il n'est pas sur la carte mémoire flash.
 
 <div id="when-can-i-not"></div>
-##Quand ne puis-je pas utiliser EncryptPad ?
+## Quand ne puis-je pas utiliser EncryptPad ?
 
 * Vous devez envoyer un fichier à quelqu'un avec qui vous **n'avez pas prédéterminé un secret partagé** (une phrase de passe ou un fichier clé). Dans ce cas, il vous faut un chiffrement asymétrique avec des clés publique et privée. Heureusement, de nombreux outils pratiques sont adaptés à la tâche. 
 
@@ -105,7 +105,7 @@ EncryptPad est une application de visualisation et d'édition de texte chiffré 
 * **IMPORTANT** : si vous avez oublié votre phrase de passe ou si vous avez perdu un fichier clé, rien ne peut être fait pour accéder à vos informations chiffrées. Il n'y a aucune porte dérobée dans les formats qu'EncryptPad prend en charge. Les développeurs d'EncryptPad n'assument aucune responsabilité en cas de fichiers corrompus ou invalides, conformément à la licence.
 
 <div id="file-types"></div>
-##Type de fichier
+## Type de fichier
 
 Le format est déterminé par l'extension du fichier. Les principales extensions des fichiers chiffrés sont GPG et EPD.
 
@@ -173,7 +173,7 @@ Quand EncryptPad ouvre le fichier chiffré protégé avec `foo.key`, les command
 Comme vous pouvez le voir, les autres applications OpenPGP peuvent aussi utiliser les clés EncryptPad.
 
 <div id="epd-file-format"></div>
-##Format EPD lors d'un chiffrement avec clé
+## Format EPD lors d'un chiffrement avec clé
 
 Un fichier enregistré peut avoir trois structures différentes selon le mode de protection :
 
@@ -186,7 +186,7 @@ Un fichier enregistré peut avoir trois structures différentes selon le mode de
 3. **Protégé par phrase de passe et clé**. Le fichier produit est un fichier OpenPGP contenant un fichier WAD tel que décrit en 2.
 
 <div id="use-curl"></div>
-##Utiliser CURL pour télécharger automatiquement des clés d'un stockage distant
+## Utiliser CURL pour télécharger automatiquement des clés d'un stockage distant
 
 Si une URL **[CURL](http://curl.haxx.se/) est précisée dans le champ **Chemin du fichier clé** de la boîte de dialogue **Définir la clé de chiffrement**, EncryptPad essaiera de lancer un processus curl pour télécharger la clé à partir d'un hôte distant. Si vous souhaitez utiliser cette fonction, vous devez définir le chemin de l'exécutable CURL dans les paramètres d'EncryptPad. 
 
@@ -199,12 +199,12 @@ Examinons un scénario d'utilisation : en voyage, vous ouvrez un fichier chiffr�
 Si le fichier tombe dans les mains d'un malfaiteur, il devra d'abord attaquer par force brute la phrase de passe afin d'obtenir l'URL de la clé et les paramètres d'authentification. Dans la mesure où une attaque par force brute prend beaucoup de temps, l'utilisateur pourra retirer la clé ou changer l'authentification afin que les paramètres précédents deviennent désuets.
 
 <div id="known-weaknesses"></div>
-##Faiblesses connues
+## Faiblesses connues
 
 * EncryptPad stocke du texte non chiffré en mémoire. Si un vidage de la mémoire est effectué automatiquement après un plantage du système ou de l'application, ou si une partie de la mémoire est enregistrée dans le fichier d'échange, les informations délicates se trouveront sur le disque. Il est parfois possible de configurer un système d'exploitation pour empêcher les vidages et l'utilisation d'un fichier d'échange. Il est recommandé de fermer EncryptPad quand il n'est pas utilisé.
 
 <div id="command-line-interface"></div>
-##Interface en ligne de commande
+## Interface en ligne de commande
 
 **encryptcli** est l'exécutable pour chiffrer ou déchiffrer des fichiers  à partir de la ligne de commande. Exécutez-le sans
 arguments pour obtenir une liste des paramètres proposés. Ci-dessous un exemple de chiffrement d'un fichier avec une clé :
@@ -219,16 +219,16 @@ arguments pour obtenir une liste des paramètres proposés. Ci-dessous un exempl
     --key-only --key-pwd-fd 3 -o texte_clair.txt.gpg 3< <(echo -n "clé")
 
 <div id="installing"></div>
-##Installer EncryptPad
+## Installer EncryptPad
 
 <div id="portable-exe"></div>
-###Exécutable portable
+### Exécutable portable
 
 Des fichiers binaires portables sont proposés pour Windows et Apple. Ils peuvent être copiés sur une clé USB ou
 placés sur un disque réseau.
 
 <div id="install-on-arch"></div>
-###Arch Linux
+### Arch Linux
 
 Utiliser des empreintes pour recevoir des clés gpg pour EncryptPad et Botan
 
@@ -243,7 +243,7 @@ Installer les paquets AUR ci-dessous :
 `pacaur` installe `botan-stable` automatiquement comme dépendance d`encryptpad`.
 
 <div id="install-on-ubuntu"></div>
-###Ubuntu ou Linux Mint par PPA
+### Ubuntu ou Linux Mint par PPA
 
 Alin Andrei de [**webupd8.org**](http://webupd8.org) à gentiment créé des paquets EncryptPad pour
 plusieurs distributions. Voir les instructions d'installation ci-dessous :
@@ -307,14 +307,14 @@ Ci-dessous se trouvent les étapes pour vérifier les hachages SHA-1 des fichier
 ## Compiler EncryptPad sous Windows
 
 <div id="prerequisites"></div>
-###Prérequis
+### Prérequis
 
 1. [**Le cadre Qt**](http://www.qt.io/download-open-source/) fondé sur MingW 32 bits (la dernière version a été testée avec Qt 5.3.2).
 2. MSYS : vous pouvez en utiliser un regroupé avec [**Git pour Windows**](http://git-scm.com/download/win). Vous utilisez probablement déjà Git.
 3. Python : toute version récente fonctionnera
 
 <div id="steps"></div>
-###Étapes
+### Étapes
 
 1. Modifier la variable d'environnement de session **PATH** afin d'inclure l'ensemble d'outils Qt et Python. **mingw32-make**, **g++**, **qmake**, **python.exe** devraient se trouver dans le chemin de recherche globale de votre session bash Git. Personnellement, je modifie bash.bashrc et ajoute une ligne comme `PATH=$PATH:/c/Python35-32:...` afin de ne pas polluer la variable PATH à l'échelle du système.
 
@@ -335,14 +335,14 @@ Si la compilation a réussi vous devriez voir l'exécutable **./bin/release/Encr
 Prenez note que si vous voulez qu'EncryptPad fonctionne en un seul exécutable sans dll, vous devez compiler le cadre Qt vous-même de façon statique. Cela prend quelques heures. De nombreuses instructions décrivant comment accomplir cela se trouvent sur Internet.  L'article le plus populaire recommande d'utiliser un script PowerShell. Bien qu'il soit très pratique (je l'ai utilisé une fois), on ne veut pas toujours mettre à niveau son PowerShell et installer les lourdes dépendances qui viennent avec. Et donc, la fois d'après, j'ai lu le script et j'ai tout fait manuellement. Heureusement qu'il n'y avait pas trop d'étapes.
 
 <div id="compile-on-mac-linux"></div>
-##Compiler EncryptPad sous Mac/Linux
+## Compiler EncryptPad sous Mac/Linux
 
 C'est plus facile que de compiler sous Windows. Tout ce que vous avez à faire est d'installer QT, Python et d'exécuter :
 
     ./configure.sh --all
 
 <div id="dynamic-build"></div>
-###Compilation dynamique
+### Compilation dynamique
 
     ./configure.sh --all --use-system-libs
 
@@ -351,7 +351,7 @@ que de compiler leur code source sous `deps`. Sous Ubuntu,  installer les
 paquets `libbotan1.10-dev` et `zlib1g-dev` avant de compiler.
 
 <div id="build-on-fedora"></div>
-###Fedora###
+### Fedora ###
 
 Installer les dépendances et outils :
 
@@ -369,11 +369,11 @@ ou pour une compilation dynamique avec des bibliothèques système :
     ./configure.sh --all --use-system-libs
 
 <div id="passphrases-in-memory"></div>
-##EncryptPad stocke-t-il les phrases de passe en mémoire pour rouvrir les fichiers ?
+## EncryptPad stocke-t-il les phrases de passe en mémoire pour rouvrir les fichiers ?
 Après avoir été saisis, une phrase de passe et un sel aléatoire sont hachés avec un algorithme S2K. Le résultat est utilisé comme clé de chiffrement pour chiffrer ou déchiffrer le fichier. Une réserve de ces résultats S2K est générée chaque fois que l'utilisateur saisit une nouvelle phrase de passe. Cela permet d'enregistrer ou de charger plusieurs fois les fichiers protégés par cette phrase de passe sans l'avoir. La taille de la réserve peut-être changée dans la boîte de dialogue Préférences. Au moment d'écrire, la dernière version a une valeur par défaut de 8. Cela signifie que vous pouvez enregistrer un fichier 8 fois avant qu'EncryptPad ne vous demande de saisir la phrase de passe de nouveau. Vous pouvez augmenter ce chiffre, mais cela aura un impact sur les performances, car les algorithmes S2K comprenant de nombreuses itérations sont lents par nature.
 
 <div id="acknowledgements"></div>
-##Remerciements
+## Remerciements
 
 EncryptPad utilise les cadres et bibliothèques suivantes :
 
@@ -386,10 +386,10 @@ EncryptPad utilise les cadres et bibliothèques suivantes :
 7. [**Jeu d'icônes famfamfam Silk 1.3**](http://www.famfamfam.com/lab/icons/silk/)
 
 <div id="integrity-verification"></div>
-##Vérification de l'intégrité d'EncryptPad
+## Vérification de l'intégrité d'EncryptPad
 
 <div id="openpgp-signing"></div>
-###Signature OpenPGP et autorité de certification
+### Signature OpenPGP et autorité de certification
 
 Tous les téléchargements associés à EncryptPad sont signés avec la clé OpenPGP suivante :
 
@@ -416,7 +416,7 @@ Il a quelques raisons pourquoi je n'ai pas simplement utilisé le certificat CA 
 4. Vérifier avec GPG les signatures des fichiers téléchargés.
 
 <div id="license"></div>
-##Licence
+## Licence
 
 EncryptPad est un logiciel libre et gratuit : vous pouvez le redistribuer ou le modifier
 selon les conditions de la [licence générale publique GNU](http://www.gnu.org/licenses/) telle que publiée par
@@ -429,7 +429,7 @@ MARCHANDE ou D'ADÉQUATION À UN BUT PARTICULIER. Voir la
 licence générale publique GNU pour plus de détails.
 
 <div id="contact"></div>
-##Contact et rétroaction
+## Contact et rétroaction
 
 Si votre question concerne EncryptPad, veuillez l'envoyer à la liste de diffusion **encryptpad@googlegroups.com** reliée au [groupe public de discussion](https://groups.google.com/d/forum/encryptpad).
 

--- a/docs/fr/tutorials/encrypt_binary_file/binary_file.md
+++ b/docs/fr/tutorials/encrypt_binary_file/binary_file.md
@@ -1,4 +1,4 @@
-#Chiffrer un fichier binaire tel qu'une image ou un fichier compressé
+# Chiffrer un fichier binaire tel qu'une image ou un fichier compressé
 
 ## Générer un nouveau fichier clé si vous souhaitez utiliser un fichier clé pour le chiffrement.
 

--- a/docs/fr/tutorials/index.md
+++ b/docs/fr/tutorials/index.md
@@ -4,12 +4,12 @@ h2
     text-align: center;
 }
 </style>
-##Tutoriels
+## Tutoriels
 
-###[1. Ouvrir un fichier texte en clair, le protéger par *phrase de passe* et l'enregistrer comme fichier GPG](open_plain_text_protect_with_passphrase/passphrase_protection.htm)
+### [1. Ouvrir un fichier texte en clair, le protéger par *phrase de passe* et l'enregistrer comme fichier GPG](open_plain_text_protect_with_passphrase/passphrase_protection.htm)
 
-###[2. Ouvrir un fichier texte en clair, le protéger par *fichier clé* et l'enregistrer comme fichier GPG](open_plain_text_protect_with_key_file/key_file_protection.htm)
+### [2. Ouvrir un fichier texte en clair, le protéger par *fichier clé* et l'enregistrer comme fichier GPG](open_plain_text_protect_with_key_file/key_file_protection.htm)
 
-###[3. Ouvrir un fichier texte en clair, le protéger à la fois par *phrase de passe et fichier clé* et l'enregistrer comme fichier EPD](open_plain_text_protect_with_key_and_passphrase/double_protection.htm)
+### [3. Ouvrir un fichier texte en clair, le protéger à la fois par *phrase de passe et fichier clé* et l'enregistrer comme fichier EPD](open_plain_text_protect_with_key_and_passphrase/double_protection.htm)
 
-###[4. Chiffrer un fichier binaire tel qu'une image ou un fichier compressé](encrypt_binary_file/binary_file.htm)
+### [4. Chiffrer un fichier binaire tel qu'une image ou un fichier compressé](encrypt_binary_file/binary_file.htm)

--- a/docs/ru/changes.md
+++ b/docs/ru/changes.md
@@ -4,9 +4,9 @@ h2
     text-align: center;
 }
 </style>
-##Версии##
+## Версии ##
 
-###Version 0.3.2.5
+### Version 0.3.2.5
 
 * Bug fixed: if a decrypted passphrase-only EPD file contained less than 4 characters, the content was ignored and EncryptPad produced an empty file. It happened because EncryptPad expected to find IWAD marker, which was 4 character long. Such files will now open correctly.
 * Bug fixed: when opening a plain-text file and saving it as encrypted, the encryption parameters did not reset to the default values but used the parameters of the last encrypted file.
@@ -26,7 +26,7 @@ h2
 * stlplus was updated from upstream. It is now 3.13.
 
 
-###Version 0.3.2.3
+### Version 0.3.2.3
 
 * Configurable s2k iteration count. It can be set per file and the default value for new files. That value is also used for protecting file keys.
 * Support for the timestamp bytes in GPG files.
@@ -39,7 +39,7 @@ h2
 * Bug fixed: In the file encryption dialogue, when clearing the passphrase and setting it again, the passphrase was ignored and the file was saved as "key only".
 * Bug fixed: In the file encryption, gpg files were encrypted with 't' flag. It lead to removal of 0x0D bytes when GPG decrypted the files because it thought that the files were textual. The problem did not manifest on Windows and when EncryptPad was used for decryption. It was only in the direction from EncryptPad to Linux/Unix GPG.
 
-###Version 0.3.2.2
+### Version 0.3.2.2
 
 * Bug fixed: In file encryption dialogue, when the key file passphrase was wrong, a message box did not inform the user.
 * BAK files support. When editing, a bak file is only created when saving for the first time.
@@ -55,6 +55,6 @@ h2
 * Fixed build on Fedora 23
 * Fixed warnings
 
-###Version 0.3.2.1
+### Version 0.3.2.1
 
 * Initial open source release

--- a/docs/ru/readme.md
+++ b/docs/ru/readme.md
@@ -1,6 +1,6 @@
 EncryptPad это приложение для просмотра и редактирования симметрично зашифрованных файлов. Приложение, так же, включает утилиту для шифрования бинарных файлов на диске. Программа предлагает эффективные способы защиты информации с помощью простого и удобного графического интерфейса и командной строки. Редактор использует наиболее распространенный формат **OpenPGP** [RFC 4880](https://tools.ietf.org/html/rfc4880). В отличит от других OpenPGP программ, главной задачей которых является ассиметричное шифрование, основная цель EncryptPad симметричное шифрование. (Перевод не завершен)
 
-##Содержимое
+## Содержимое
 * [Возможности](#features)
 * [Поддерживаемые платформы](#supported-platforms)
 * [Why use EncryptPad?](#why-use-encryptpad)
@@ -34,7 +34,7 @@ EncryptPad это приложение для просмотра и редакт
 * [Contact and feedback](#contact)
 
 <div id="features"></div>
-##Features
+## Features
 
 * **Symmetric** encryption
 * **Passphrase** protection
@@ -57,7 +57,7 @@ EncryptPad это приложение для просмотра и редакт
 * Compression: **ZLIB, ZIP**
 
 <div id="supported-platforms"></div>
-##Supported platforms
+## Supported platforms
 
 * Windows
 
@@ -66,7 +66,7 @@ EncryptPad это приложение для просмотра и редакт
 * Mac OS
 
 <div id="why-use-encryptpad"></div>
-##Why use EncryptPad?
+## Why use EncryptPad?
 
 * **Multi-platform** codebase: it has been compiled on three popular operating systems and can be adapted to more.
 
@@ -81,7 +81,7 @@ EncryptPad это приложение для просмотра и редакт
 * **Double protection**: randomly generated key files in addition to passphrases.
 
 <div id="when-encryptpad"></div>
-##When do I need EncryptPad?
+## When do I need EncryptPad?
 
 * You have a file containing sensitive information such as account names, passphrases or IDs. It is stored on an unprotected media or you can't control who accesses the file, whether it is located on a computer at work, a laptop while on the move, a memory stick or a cloud drive.
 
@@ -92,7 +92,7 @@ EncryptPad это приложение для просмотра и редакт
 * You need protection against a brute force attack in case your storage gets in somebody's hands. EncryptPad allows to generate a key and store it separately from encrypted information. The unwanted person would need two secrets to open an encrypted file: the passphrase and the key. Consider this example: you store your encrypted file on a memory stick, and protect it with a passphrase. In addition to that, you protect the file with a file key and store the key on computers where you open the file. If the memory stick is lost, the passphrase is not enough to decrypt your information. The key file is also needed and it is not on the memory stick.
 
 <div id="when-can-i-not"></div>
-##When can I not use EncryptPad?
+## When can I not use EncryptPad?
 
 * You need to send a file to somebody with whom you have **not prearranged a shared secret** (a passphrase or a key file). In this case, you need asymmetric encryption with public and private keys. Fortunately, there are many convenient tools suitable for the task. 
 
@@ -105,7 +105,7 @@ EncryptPad это приложение для просмотра и редакт
 * **IMPORTANT**: If you forgot your passphrase or lost a key file, there is nothing that can be done to open your encrypted information. There are no backdoors in the formats that EncryptPad supports. EncryptPad developers take no responsibility for corrupted or invalid files in accordance with the license.
 
 <div id="file-types"></div>
-##File types
+## File types
 
 The format is determined by an extension of a file. Main extensions of encrypted files are GPG and EPD.
 
@@ -137,7 +137,7 @@ EncryptPad specific format. Other OpenPGP software will not be able to open it u
 \* Key file location is persisted in the header of an encrypted file so the user does not need to specify it when decrypting.
 
 <div id="key-file"></div>
-##What is an EncryptPad key file?
+## What is an EncryptPad key file?
 In symmetric encryption the same sequence is used to encrypt and decrypt data. The user or another
 application usually provides this sequence in the form of an entered passphrase or a file. In addition to
 entered passphrases, EncryptPad generates files with random sequences called "key files".
@@ -173,7 +173,7 @@ When EncryptPad opens the encrypted file protected with `foo.key`, the equivalen
 As you see, other OpenPGP implementations can also use EncryptPad keys.
 
 <div id="epd-file-format"></div>
-##EPD file format when encrypting with a key
+## EPD file format when encrypting with a key
 
 There are three different structures a saved file can have depending on protection mode:
 
@@ -186,7 +186,7 @@ There are three different structures a saved file can have depending on protecti
 3. **Protected with passphrase and key**. The resulting file is an OpenPGP file containing a WAD file as explained in 2.
 
 <div id="use-curl"></div>
-##Use CURL to automatically download keys from a remote storage
+## Use CURL to automatically download keys from a remote storage
 
 If **[CURL](http://curl.haxx.se/)** URL is specified in **Key File Path** field in the **Set Encryption Key** dialogue, EncryptPad will attempt to start a curl process to download the key from a remote host. If you want to use this feature, you need to set the path to the CURL executable in the EncryptPad settings. 
 
@@ -199,12 +199,12 @@ Consider this use case scenario: you travel with your laptop and open an encrypt
 If this file gets into the hands of a wrongdoer, he or she will need to brute force the passphrase first to be able to obtain the key URL and the authentication parameters. Since a brute force attack takes a lot of time, the user will be able to remove the key or change the authentication so the previous parameters become obsolete.
 
 <div id="known-weaknesses"></div>
-##Known weaknesses
+## Known weaknesses
 
 * EncryptPad stores unencrypted text in memory. If a memory dump is automatically taken after a system or application crash or some of the memory is saved to a swap file, the sensitive information will be present on the disk. Sometimes it is possible to configure an operating system not to use a dump and swap files. It is a good practice to close EncryptPad when not in use.
 
 <div id="command-line-interface"></div>
-##Command line interface
+## Command line interface
 
 **encryptcli** is the executable to encrypt / decrypt files in command line. Run it without
 arguments to see available parameters. Below is an example of encrypting a file with a key:
@@ -219,16 +219,16 @@ arguments to see available parameters. Below is an example of encrypting a file 
     --key-only --key-pwd-fd 3 -o plain_text.txt.gpg 3< <(echo -n "key")
 
 <div id="installing"></div>
-##Installing EncryptPad
+## Installing EncryptPad
 
 <div id="portable-exe"></div>
-###Portable executable
+### Portable executable
 
 Portable binaries are available for Windows and macOS. They can be copied on a memory stick or
 placed on a network share.
 
 <div id="install-on-arch"></div>
-###Arch Linux
+### Arch Linux
 
 Use fingerprints to receive gpg keys for EncryptPad and Botan.
 
@@ -243,7 +243,7 @@ Install the AUR packages below:
 `pacaur` installs `botan-stable` automatically as `encryptpad` dependency.
 
 <div id="install-on-ubuntu"></div>
-###Ubuntu or Linux Mint via PPA
+### Ubuntu or Linux Mint via PPA
 
 Alin Andrei from [**webupd8.org**](http://webupd8.org) kindly created EncryptPad packages for
 several distributions. See instructions below on how to install them.
@@ -304,17 +304,17 @@ Below are steps to verify the SHA-1 hashes of the source files in [Launchpad web
     encryptpad0_3_2_5_webupd8_ppa_changes/encryptpad_0.3.2.5-1~webupd8~yakkety1_source.changes
 
 <div id="compile-on-windows"></div>
-##Compile EncryptPad on Windows
+## Compile EncryptPad on Windows
 
 <div id="prerequisites"></div>
-###Prerequisites
+### Prerequisites
 
 1. [**Qt framework**](http://www.qt.io/download-open-source/) based on MingW 32 bit (the latest build has been tested with Qt 5.3.2).
 2. MSYS: you can use one bundled with [**Git For Windows**](http://git-scm.com/download/win). You probably use Git anyway.
 3. Python: any recent version will work.
 
 <div id="steps"></div>
-###Steps
+### Steps
 
 1. Modify the session **PATH** environment variable to include the Qt build toolset and Python. **mingw32-make**, **g++**, **qmake**, **python.exe** should be in the global search path in your Git Bash session. I personally modify bash.bashrc and add a line like `PATH=$PATH:/c/Python35-32:...` not to pollute the system wide PATH variable.
 
@@ -335,14 +335,14 @@ If the build is successful, you should see the executable **./bin/release/Encryp
 Note that if you want EncryptPad to work as a single executable without dlls, you need to build Qt framework yourself statically. It takes a few hours. There are plenty of instructions on how to do this in the Internet. The most popular article recommends using a PowerShell script. While it is convenient and I did it once, sometimes you don't want to upgrade your PowerShell and install heavy dependencies coming with it. So the next time I had to do that, I read the script and did everything manually. Luckily there are not too many steps in it.
 
 <div id="compile-on-mac-linux"></div>
-##Compile EncryptPad on Mac/Linux
+## Compile EncryptPad on Mac/Linux
 
 It is easier than building on Windows. All you need is to install Qt, Python and run:
 
     ./configure.sh --all
 
 <div id="dynamic-build"></div>
-###Dynamic build
+### Dynamic build
 
     ./configure.sh --all --use-system-libs
 
@@ -351,7 +351,7 @@ of compiling their source code under `deps`. On Ubuntu, install `libbotan1.10-de
 packages before building.
 
 <div id="build-on-fedora"></div>
-###Fedora###
+### Fedora ###
 
 Install dependencies and tools:
 
@@ -369,11 +369,11 @@ For a dynamic build with using the system libraries:
     ./configure.sh --all --use-system-libs
 
 <div id="passphrases-in-memory"></div>
-##Does EncryptPad store passphrases in the memory to reopen files?
+## Does EncryptPad store passphrases in the memory to reopen files?
 No, it does not. After being entered, a passphrase and random salt are hashed with an S2K algorithm. The result is used as the encryption key to encrypt or decrypt the file. A pool of these S2K results is generated every time the user enters a new passphrase. It allows to save and load files protected with this passphrase multiple times without having the passphrase. The size of the pool can be changed in the Preferences dialogue. The latest version at the moment of writing has this number set to 8 by default. It means that you can save a file 8 times before EncryptPad will ask you to enter the passphrase again. You can increase this number but it will have an impact on the performance because S2K algorithms with many iterations are slow by design.
 
 <div id="acknowledgements"></div>
-##Acknowledgements
+## Acknowledgements
 
 EncryptPad uses the following frameworks and libraries:
 
@@ -386,10 +386,10 @@ EncryptPad uses the following frameworks and libraries:
 7. [**famfamfam Silk iconset 1.3**](http://www.famfamfam.com/lab/icons/silk/)
 
 <div id="integrity-verification"></div>
-##EncryptPad integrity verification
+## EncryptPad integrity verification
 
 <div id="openpgp-signing"></div>
-###OpenPGP signing and certification authority
+### OpenPGP signing and certification authority
 
 All EncryptPad related downloads are signed with the following OpenPGP key.
 
@@ -416,7 +416,7 @@ There is a few reasons why I did not simply use the CA certificate:
 4. Verify signatures on the downloaded files with GPG.
 
 <div id="license"></div>
-##License
+## License
 
 EncryptPad is free software: you can redistribute it and/or modify
 it under the terms of the [GNU General Public License](http://www.gnu.org/licenses/) as published by
@@ -429,7 +429,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 <div id="contact"></div>
-##Contact and feedback
+## Contact and feedback
 
 If your question is related to EncryptPad, send it to the mailing list: **encryptpad@googlegroups.com** linked to [the public discussion group](https://groups.google.com/d/forum/encryptpad).
 

--- a/docs/ru/tutorials/encrypt_binary_file/binary_file.md
+++ b/docs/ru/tutorials/encrypt_binary_file/binary_file.md
@@ -1,4 +1,4 @@
-#Encrypt a binary file such as a picture or an archive
+# Encrypt a binary file such as a picture or an archive
 
 ## Generate a new key file if you want to use a key file for encryption.
 

--- a/docs/ru/tutorials/index.md
+++ b/docs/ru/tutorials/index.md
@@ -4,12 +4,12 @@ h2
     text-align: center;
 }
 </style>
-##Инструкции
+## Инструкции
 
-###[1. Open a plain text file, protect it with *a passphrase* and save as a GPG file](open_plain_text_protect_with_passphrase/passphrase_protection.htm)
+### [1. Open a plain text file, protect it with *a passphrase* and save as a GPG file](open_plain_text_protect_with_passphrase/passphrase_protection.htm)
 
-###[2. Open a plain text file, protect it with *a key file* and save as a GPG file](open_plain_text_protect_with_key_file/key_file_protection.htm)
+### [2. Open a plain text file, protect it with *a key file* and save as a GPG file](open_plain_text_protect_with_key_file/key_file_protection.htm)
 
-###[3. Open a plain text file, protect it with both *a passphrase and key file* then save it as an EPD file](open_plain_text_protect_with_key_and_passphrase/double_protection.htm)
+### [3. Open a plain text file, protect it with both *a passphrase and key file* then save it as an EPD file](open_plain_text_protect_with_key_and_passphrase/double_protection.htm)
 
-###[4. Encrypt a binary file such as a picture or an archive](encrypt_binary_file/binary_file.htm)
+### [4. Encrypt a binary file such as a picture or an archive](encrypt_binary_file/binary_file.htm)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
