### PR TITLE
semicolon (';') as trailing character

### DIFF
--- a/encryptpad.desktop
+++ b/encryptpad.desktop
@@ -8,4 +8,4 @@ Exec=encryptpad %f
 Categories=Utility;TextEditor;
 StartupNotify=false
 Terminal=false
-MimeType=application/x-encryptpad
+MimeType=application/x-encryptpad;

--- a/linux_deployment/AppDir/encryptpad.desktop
+++ b/linux_deployment/AppDir/encryptpad.desktop
@@ -8,4 +8,4 @@ Exec=encryptpad.wrapper %f
 Categories=Utility;TextEditor;
 StartupNotify=false
 Terminal=false
-MimeType=application/x-encryptpad
+MimeType=application/x-encryptpad;


### PR DESCRIPTION
Fix `desktop-file-validate`: encryptpad.desktop: error: value "application/x-encryptpad" for string list key "MimeType" in group "Desktop Entry" does not have a semicolon (';') as trailing character

Reference:
https://travis-ci.org/AppImage/AppImageHub/builds/266112663#L543