### PR TITLE
Fix search dialogs to focus on the text field (issue #98)

### DIFF
--- a/qt_ui/find_and_replace.cpp
+++ b/qt_ui/find_and_replace.cpp
@@ -28,6 +28,7 @@ FindAndReplace::FindAndReplace(QWidget *parent) :
     ui->setupUi(this);
     setMinimumSize(sizeHint());
     adjustSize();
+    ui->uiFind->setFocus();
 }
 
 FindAndReplace::~FindAndReplace()

--- a/qt_ui/find_and_replace.cpp
+++ b/qt_ui/find_and_replace.cpp
@@ -28,7 +28,6 @@ FindAndReplace::FindAndReplace(QWidget *parent) :
     ui->setupUi(this);
     setMinimumSize(sizeHint());
     adjustSize();
-    ui->uiFind->setFocus();
 }
 
 FindAndReplace::~FindAndReplace()
@@ -51,10 +50,15 @@ void FindAndReplace::SetFind(const QString &str)
     ui->uiFind->setText(str);
 }
 
+void FindAndReplace::setFindFocus()
+{
+    ui->uiFind->setFocus();
+}
+
 void FindAndReplace::on_FindAndReplace_finished(int result)
 {
     (void)result;
-    ui->uiFind->setFocus();
+    setFindFocus();
 }
 
 void FindAndReplace::on_uiFindNext_clicked()

--- a/qt_ui/find_and_replace.h
+++ b/qt_ui/find_and_replace.h
@@ -37,6 +37,7 @@ public:
     QString GetFind() const;
     QString GetReplace() const;
     void SetFind(const QString &str);
+    void setFindFocus();
 
 private:
     Ui::FindAndReplace *ui;

--- a/qt_ui/find_dialog.cpp
+++ b/qt_ui/find_dialog.cpp
@@ -12,6 +12,7 @@ FindDialog::FindDialog(QWidget *parent) :
     ui->setupUi(this);
     setMinimumSize(sizeHint());
     adjustSize();
+    ui->uiFind->setFocus();
 }
 
 FindDialog::~FindDialog()

--- a/qt_ui/find_dialog.cpp
+++ b/qt_ui/find_dialog.cpp
@@ -12,7 +12,6 @@ FindDialog::FindDialog(QWidget *parent) :
     ui->setupUi(this);
     setMinimumSize(sizeHint());
     adjustSize();
-    ui->uiFind->setFocus();
 }
 
 FindDialog::~FindDialog()
@@ -23,6 +22,11 @@ FindDialog::~FindDialog()
 void FindDialog::setFindWhat(const QString &text)
 {
     ui->uiFind->setText(text);
+}
+
+void FindDialog::setFindFocus()
+{
+    ui->uiFind->setFocus();
 }
 
 void FindDialog::on_uiFindNext_clicked()
@@ -38,5 +42,5 @@ void FindDialog::on_uiFind_textChanged(const QString &text)
 void FindDialog::on_FindDialog_finished(int result)
 {
     (void)result;
-    ui->uiFind->setFocus();
+    setFindFocus();
 }

--- a/qt_ui/find_dialog.h
+++ b/qt_ui/find_dialog.h
@@ -16,6 +16,7 @@ public:
     ~FindDialog();
 
     void setFindWhat(const QString &text);
+    void setFindFocus();
 
 private:
     Ui::FindDialog *ui;

--- a/qt_ui/mainwindow.cpp
+++ b/qt_ui/mainwindow.cpp
@@ -1505,7 +1505,9 @@ void MainWindow::replace()
     QString selectedText = textEdit->textCursor().selectedText();
     if(!selectedText.isEmpty())
         replaceDialog->SetFind(selectedText);
+
     replaceDialog->show();
+    replaceDialog->setFindFocus();
 }
 
 void MainWindow::readOnlyToggled(bool flag)
@@ -1542,6 +1544,7 @@ void MainWindow::search()
         findDialog->setFindWhat(selectedText);
 
     findDialog->show();
+    findDialog->setFindFocus();
 }
 
 void MainWindow::generatePassphrase()


### PR DESCRIPTION
Hi!

I've fixed the bug from issue #98 

When I press `CTRL-F` to open the _Find dialog_, the focus remains on the text and not on the search field.

Sometimes, this issue is a bit annoying if you're using only the keyboard because you always need to click on the search text field to enter the search word.

This problem does not occur when I open the search dialog by using the mouse, clicking on "Edit... -> Find...".