### PR TITLE
Fix 'passphrase focus' on text field (issue #121)

### DIFF
--- a/qt_ui/get_passphrase_dialog.cpp
+++ b/qt_ui/get_passphrase_dialog.cpp
@@ -26,6 +26,7 @@ GetPassphraseDialog::GetPassphraseDialog(QWidget *parent) :
     ui(new Ui::GetPassphraseDialog)
 {
     ui->setupUi(this);
+    ui->uiPassphrase->setFocus();
 }
 
 GetPassphraseDialog::~GetPassphraseDialog()

--- a/qt_ui/get_passphrase_or_key_dialog.cpp
+++ b/qt_ui/get_passphrase_or_key_dialog.cpp
@@ -30,6 +30,7 @@ GetPassphraseOrKeyDialog::GetPassphraseOrKeyDialog(QWidget *parent, FileRequestS
     fileRequestService(fileRequestService_p)
 {
     ui->setupUi(this);
+    ui->uiPassphrase->setFocus();
 }
 
 GetPassphraseOrKeyDialog::~GetPassphraseOrKeyDialog()


### PR DESCRIPTION
Hi @evpo !

When I open a ".epd" file with a passphrase set, the focus is on 'Passphrase' text field. So, I don't need to use the mouse to click to start putting my password.

When I open a ".gpg" file, there is no focus. So, I need to use the mouse to click in the 'Passphrase' field to start putting my password.

I think this feature is important because it is a bit boring to use the mouse every time when I open a '.gpg' file.

Best regards,