### PR TITLE
Included cstdint in emsg_constants.h and stdexcept in openpgp_conversions.h

### DIFF
--- a/deps/libencryptmsg/src/lib/emsg_constants.h
+++ b/deps/libencryptmsg/src/lib/emsg_constants.h
@@ -7,6 +7,7 @@
 #pragma once
 #include <cstddef>
 #include <limits>
+#include <cstdint>
 #include "algo_spec.h"
 
 namespace EncryptMsg

--- a/deps/libencryptmsg/src/lib/openpgp_conversions.h
+++ b/deps/libencryptmsg/src/lib/openpgp_conversions.h
@@ -7,6 +7,7 @@
 #pragma once
 #include <cstdint>
 #include <cstddef>
+#include <stdexcept>
 
 namespace EncryptMsg
 {


### PR DESCRIPTION
Had a problem compiling this in fedora, now it works